### PR TITLE
Dtype rename

### DIFF
--- a/src/linalg/dual.rs
+++ b/src/linalg/dual.rs
@@ -25,13 +25,13 @@ impl<
 
 // TODO: Expand on this instead of including in Variable??
 pub trait DualConvert {
-    type Alias<D: Numeric>;
-    fn dual_convert<D: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<D>;
+    type Alias<T: Numeric>;
+    fn dual_convert<T: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<T>;
 }
 
 impl<const R: usize, const C: usize, T: Numeric> DualConvert for Matrix<R, C, T> {
-    type Alias<D: Numeric> = Matrix<R, C, D>;
-    fn dual_convert<D: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<D> {
+    type Alias<TT: Numeric> = Matrix<R, C, TT>;
+    fn dual_convert<TT: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<TT> {
         other.map(|x| x.into())
     }
 }

--- a/src/linalg/forward_prop.rs
+++ b/src/linalg/forward_prop.rs
@@ -2,9 +2,7 @@ use paste::paste;
 
 use super::{
     dual::{DualAllocator, DualVector},
-    AllocatorBuffer,
-    Diff,
-    MatrixDim,
+    AllocatorBuffer, Diff, MatrixDim,
 };
 use crate::{
     dtype,
@@ -29,7 +27,7 @@ use crate::{
 ///     variables::SO2,
 /// };
 ///
-/// fn f<D: Numeric>(x: SO2<D>, y: SO2<D>) -> VectorX<D> {
+/// fn f<T: Numeric>(x: SO2<T>, y: SO2<T>) -> VectorX<T> {
 ///     x.ominus(&y)
 /// }
 ///
@@ -48,12 +46,12 @@ macro_rules! forward_maker {
     ($num:expr, $( ($name:ident: $var:ident) ),*) => {
         paste! {
             #[allow(unused_assignments)]
-            fn [<jacobian_ $num>]<$( $var: Variable<Alias<dtype> = $var>, )* F: Fn($($var::Alias<Self::D>,)*) -> VectorX<Self::D>>
+            fn [<jacobian_ $num>]<$( $var: Variable<Alias<dtype> = $var>, )* F: Fn($($var::Alias<Self::T>,)*) -> VectorX<Self::T>>
                     (f: F, $($name: &$var,)*) -> DiffResult<VectorX, MatrixX>{
                 // Prepare variables
                 let mut curr_dim = 0;
                 $(
-                    let $name: $var::Alias<Self::D> = $var::dual($name, curr_dim);
+                    let $name: $var::Alias<Self::T> = $var::dual($name, curr_dim);
                     curr_dim += $name.dim();
                 )*
 
@@ -85,7 +83,7 @@ where
     DefaultAllocator: DualAllocator<N>,
     DualVector<N>: Copy,
 {
-    type D = DualVector<N>;
+    type T = DualVector<N>;
 
     forward_maker!(1, (v1: V1));
     forward_maker!(2, (v1: V1), (v2: V2));

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -73,9 +73,9 @@ pub struct DiffResult<V, G> {
 macro_rules! fn_maker {
     (grad, $num:expr, $( ($name:ident: $var:ident) ),*) => {
         paste! {
-            fn [<gradient_ $num>]<$( $var: Variable<Alias<dtype> = $var>, )* F: Fn($($var::Alias<Self::D>,)*) -> Self::D>
+            fn [<gradient_ $num>]<$( $var: Variable<Alias<dtype> = $var>, )* F: Fn($($var::Alias<Self::T>,)*) -> Self::T>
                     (f: F, $($name: &$var,)*) -> DiffResult<dtype, VectorX>{
-                    let f_wrapped = |$($name: $var::Alias<Self::D>,)*| vectorx![f($($name.clone(),)*)];
+                    let f_wrapped = |$($name: $var::Alias<Self::T>,)*| vectorx![f($($name.clone(),)*)];
                     let DiffResult { value, diff } = Self::[<jacobian_ $num>](f_wrapped, $($name,)*);
                     let diff = VectorX::from_iterator(diff.len(), diff.iter().cloned());
                     DiffResult { value: value[0], diff }
@@ -85,7 +85,7 @@ macro_rules! fn_maker {
 
     (jac, $num:expr, $( ($name:ident: $var:ident) ),*) => {
         paste! {
-            fn [<jacobian_ $num>]<$( $var: Variable<Alias<$crate::dtype>=$var>, )* F: Fn($($var::Alias<Self::D>,)*) -> VectorX<Self::D>>
+            fn [<jacobian_ $num>]<$( $var: Variable<Alias<$crate::dtype>=$var>, )* F: Fn($($var::Alias<Self::T>,)*) -> VectorX<Self::T>>
                     (f: F, $($name: &$var,)*) -> DiffResult<VectorX, MatrixX>;
         }
     };
@@ -101,7 +101,7 @@ macro_rules! fn_maker {
 /// recommend [ForwardProp] which functions using dual numbers.
 pub trait Diff {
     /// The dtype of the variables
-    type D: Numeric;
+    type T: Numeric;
 
     fn_maker!(grad, 1, (v1: V1));
     fn_maker!(grad, 2, (v1: V1), (v2: V2));

--- a/src/linalg/nalgebra_wrap.rs
+++ b/src/linalg/nalgebra_wrap.rs
@@ -13,100 +13,100 @@ pub type AllocatorBuffer<N> = <DefaultAllocator as Allocator<N>>::Buffer<dtype>;
 
 // ------------------------- Vector/Matrix Aliases ------------------------- //
 // Vectors
-pub type Vector<const N: usize, D = dtype> = na::SVector<D, N>;
-pub type VectorX<D = dtype> = na::DVector<D>;
-pub type Vector1<D = dtype> = na::SVector<D, 1>;
-pub type Vector2<D = dtype> = na::SVector<D, 2>;
-pub type Vector3<D = dtype> = na::SVector<D, 3>;
-pub type Vector4<D = dtype> = na::SVector<D, 4>;
-pub type Vector5<D = dtype> = na::SVector<D, 5>;
-pub type Vector6<D = dtype> = na::SVector<D, 6>;
+pub type Vector<const N: usize, T = dtype> = na::SVector<T, N>;
+pub type VectorX<T = dtype> = na::DVector<T>;
+pub type Vector1<T = dtype> = na::SVector<T, 1>;
+pub type Vector2<T = dtype> = na::SVector<T, 2>;
+pub type Vector3<T = dtype> = na::SVector<T, 3>;
+pub type Vector4<T = dtype> = na::SVector<T, 4>;
+pub type Vector5<T = dtype> = na::SVector<T, 5>;
+pub type Vector6<T = dtype> = na::SVector<T, 6>;
 
 // Matrices
 // square
-pub type MatrixX<D = dtype> = na::DMatrix<D>;
-pub type Matrix1<D = dtype> = na::Matrix1<D>;
-pub type Matrix2<D = dtype> = na::Matrix2<D>;
-pub type Matrix3<D = dtype> = na::Matrix3<D>;
-pub type Matrix4<D = dtype> = na::Matrix4<D>;
-pub type Matrix5<D = dtype> = na::Matrix5<D>;
-pub type Matrix6<D = dtype> = na::Matrix6<D>;
+pub type MatrixX<T = dtype> = na::DMatrix<T>;
+pub type Matrix1<T = dtype> = na::Matrix1<T>;
+pub type Matrix2<T = dtype> = na::Matrix2<T>;
+pub type Matrix3<T = dtype> = na::Matrix3<T>;
+pub type Matrix4<T = dtype> = na::Matrix4<T>;
+pub type Matrix5<T = dtype> = na::Matrix5<T>;
+pub type Matrix6<T = dtype> = na::Matrix6<T>;
 
 // row
-pub type Matrix1xX<D = dtype> = na::Matrix1xX<D>;
-pub type Matrix1x2<D = dtype> = na::Matrix1x2<D>;
-pub type Matrix1x3<D = dtype> = na::Matrix1x3<D>;
-pub type Matrix1x4<D = dtype> = na::Matrix1x4<D>;
-pub type Matrix1x5<D = dtype> = na::Matrix1x5<D>;
-pub type Matrix1x6<D = dtype> = na::Matrix1x6<D>;
+pub type Matrix1xX<T = dtype> = na::Matrix1xX<T>;
+pub type Matrix1x2<T = dtype> = na::Matrix1x2<T>;
+pub type Matrix1x3<T = dtype> = na::Matrix1x3<T>;
+pub type Matrix1x4<T = dtype> = na::Matrix1x4<T>;
+pub type Matrix1x5<T = dtype> = na::Matrix1x5<T>;
+pub type Matrix1x6<T = dtype> = na::Matrix1x6<T>;
 
 // two rows
-pub type Matrix2xX<D = dtype> = na::Matrix2xX<D>;
-pub type Matrix2x3<D = dtype> = na::Matrix2x3<D>;
-pub type Matrix2x4<D = dtype> = na::Matrix2x4<D>;
-pub type Matrix2x5<D = dtype> = na::Matrix2x5<D>;
-pub type Matrix2x6<D = dtype> = na::Matrix2x6<D>;
+pub type Matrix2xX<T = dtype> = na::Matrix2xX<T>;
+pub type Matrix2x3<T = dtype> = na::Matrix2x3<T>;
+pub type Matrix2x4<T = dtype> = na::Matrix2x4<T>;
+pub type Matrix2x5<T = dtype> = na::Matrix2x5<T>;
+pub type Matrix2x6<T = dtype> = na::Matrix2x6<T>;
 
 // three rows
-pub type Matrix3xX<D = dtype> = na::Matrix3xX<D>;
-pub type Matrix3x2<D = dtype> = na::Matrix3x2<D>;
-pub type Matrix3x4<D = dtype> = na::Matrix3x4<D>;
-pub type Matrix3x5<D = dtype> = na::Matrix3x5<D>;
-pub type Matrix3x6<D = dtype> = na::Matrix3x6<D>;
+pub type Matrix3xX<T = dtype> = na::Matrix3xX<T>;
+pub type Matrix3x2<T = dtype> = na::Matrix3x2<T>;
+pub type Matrix3x4<T = dtype> = na::Matrix3x4<T>;
+pub type Matrix3x5<T = dtype> = na::Matrix3x5<T>;
+pub type Matrix3x6<T = dtype> = na::Matrix3x6<T>;
 
 // four rows
-pub type Matrix4xX<D = dtype> = na::Matrix4xX<D>;
-pub type Matrix4x2<D = dtype> = na::Matrix4x2<D>;
-pub type Matrix4x3<D = dtype> = na::Matrix4x3<D>;
-pub type Matrix4x5<D = dtype> = na::Matrix4x5<D>;
-pub type Matrix4x6<D = dtype> = na::Matrix4x6<D>;
+pub type Matrix4xX<T = dtype> = na::Matrix4xX<T>;
+pub type Matrix4x2<T = dtype> = na::Matrix4x2<T>;
+pub type Matrix4x3<T = dtype> = na::Matrix4x3<T>;
+pub type Matrix4x5<T = dtype> = na::Matrix4x5<T>;
+pub type Matrix4x6<T = dtype> = na::Matrix4x6<T>;
 
 // five rows
-pub type Matrix5xX<D = dtype> = na::Matrix5xX<D>;
-pub type Matrix5x2<D = dtype> = na::Matrix5x2<D>;
-pub type Matrix5x3<D = dtype> = na::Matrix5x3<D>;
-pub type Matrix5x4<D = dtype> = na::Matrix5x4<D>;
-pub type Matrix5x6<D = dtype> = na::Matrix5x6<D>;
+pub type Matrix5xX<T = dtype> = na::Matrix5xX<T>;
+pub type Matrix5x2<T = dtype> = na::Matrix5x2<T>;
+pub type Matrix5x3<T = dtype> = na::Matrix5x3<T>;
+pub type Matrix5x4<T = dtype> = na::Matrix5x4<T>;
+pub type Matrix5x6<T = dtype> = na::Matrix5x6<T>;
 
 // six rows
-pub type Matrix6xX<D = dtype> = na::Matrix6xX<D>;
-pub type Matrix6x2<D = dtype> = na::Matrix6x2<D>;
-pub type Matrix6x3<D = dtype> = na::Matrix6x3<D>;
-pub type Matrix6x4<D = dtype> = na::Matrix6x4<D>;
-pub type Matrix6x5<D = dtype> = na::Matrix6x5<D>;
+pub type Matrix6xX<T = dtype> = na::Matrix6xX<T>;
+pub type Matrix6x2<T = dtype> = na::Matrix6x2<T>;
+pub type Matrix6x3<T = dtype> = na::Matrix6x3<T>;
+pub type Matrix6x4<T = dtype> = na::Matrix6x4<T>;
+pub type Matrix6x5<T = dtype> = na::Matrix6x5<T>;
 
 // dynamic rows
-pub type MatrixXx2<D = dtype> = na::MatrixXx2<D>;
-pub type MatrixXx3<D = dtype> = na::MatrixXx3<D>;
-pub type MatrixXx4<D = dtype> = na::MatrixXx4<D>;
-pub type MatrixXx5<D = dtype> = na::MatrixXx5<D>;
-pub type MatrixXx6<D = dtype> = na::MatrixXx6<D>;
-pub type MatrixXxN<const N: usize, D = dtype> =
-    na::Matrix<D, Dyn, Const<N>, na::VecStorage<D, Dyn, Const<N>>>;
+pub type MatrixXx2<T = dtype> = na::MatrixXx2<T>;
+pub type MatrixXx3<T = dtype> = na::MatrixXx3<T>;
+pub type MatrixXx4<T = dtype> = na::MatrixXx4<T>;
+pub type MatrixXx5<T = dtype> = na::MatrixXx5<T>;
+pub type MatrixXx6<T = dtype> = na::MatrixXx6<T>;
+pub type MatrixXxN<const N: usize, T = dtype> =
+    na::Matrix<T, Dyn, Const<N>, na::VecStorage<T, Dyn, Const<N>>>;
 
 // Views - aka references of matrices
-pub type MatrixViewX<'a, D = dtype> = na::MatrixView<'a, D, Dyn, Dyn>;
+pub type MatrixViewX<'a, T = dtype> = na::MatrixView<'a, T, Dyn, Dyn>;
 
-pub type Matrix<const R: usize, const C: usize = 1, D = dtype> = na::Matrix<
-    D,
+pub type Matrix<const R: usize, const C: usize = 1, T = dtype> = na::Matrix<
+    T,
     Const<R>,
     Const<C>,
-    <na::DefaultAllocator as Allocator<Const<R>, Const<C>>>::Buffer<D>,
+    <na::DefaultAllocator as Allocator<Const<R>, Const<C>>>::Buffer<T>,
 >;
-pub type MatrixView<'a, const R: usize, const C: usize = 1, D = dtype> =
-    na::MatrixView<'a, D, Const<R>, Const<C>>;
+pub type MatrixView<'a, const R: usize, const C: usize = 1, T = dtype> =
+    na::MatrixView<'a, T, Const<R>, Const<C>>;
 
-pub type VectorView<'a, const N: usize, D = dtype> = na::VectorView<'a, D, Const<N>>;
-pub type VectorViewX<'a, D = dtype> = na::VectorView<'a, D, Dyn>;
-pub type VectorView1<'a, D = dtype> = na::VectorView<'a, D, Const<1>>;
-pub type VectorView2<'a, D = dtype> = na::VectorView<'a, D, Const<2>>;
-pub type VectorView3<'a, D = dtype> = na::VectorView<'a, D, Const<3>>;
-pub type VectorView4<'a, D = dtype> = na::VectorView<'a, D, Const<4>>;
-pub type VectorView5<'a, D = dtype> = na::VectorView<'a, D, Const<5>>;
-pub type VectorView6<'a, D = dtype> = na::VectorView<'a, D, Const<6>>;
+pub type VectorView<'a, const N: usize, T = dtype> = na::VectorView<'a, T, Const<N>>;
+pub type VectorViewX<'a, T = dtype> = na::VectorView<'a, T, Dyn>;
+pub type VectorView1<'a, T = dtype> = na::VectorView<'a, T, Const<1>>;
+pub type VectorView2<'a, T = dtype> = na::VectorView<'a, T, Const<2>>;
+pub type VectorView3<'a, T = dtype> = na::VectorView<'a, T, Const<3>>;
+pub type VectorView4<'a, T = dtype> = na::VectorView<'a, T, Const<4>>;
+pub type VectorView5<'a, T = dtype> = na::VectorView<'a, T, Const<5>>;
+pub type VectorView6<'a, T = dtype> = na::VectorView<'a, T, Const<6>>;
 
 // Generic, taking in sizes with Const
-pub type VectorDim<N, D = dtype> = OVector<D, N>;
-pub type MatrixDim<R, C = Const<1>, D = dtype> =
-    na::Matrix<D, R, C, <na::DefaultAllocator as Allocator<R, C>>::Buffer<D>>;
-pub type MatrixViewDim<'a, R, C = Const<1>, D = dtype> = na::MatrixView<'a, D, R, C>;
+pub type VectorDim<N, T = dtype> = OVector<T, N>;
+pub type MatrixDim<R, C = Const<1>, T = dtype> =
+    na::Matrix<T, R, C, <na::DefaultAllocator as Allocator<R, C>>::Buffer<T>>;
+pub type MatrixViewDim<'a, R, C = Const<1>, T = dtype> = na::MatrixView<'a, T, R, C>;

--- a/src/linalg/numerical_diff.rs
+++ b/src/linalg/numerical_diff.rs
@@ -84,7 +84,7 @@ macro_rules! numerical_maker {
 }
 
 impl<const PWR: i32> Diff for NumericalDiff<PWR> {
-    type D = dtype;
+    type T = dtype;
 
     numerical_maker!(1, (0, v1, V1));
     numerical_maker!(2, (0, v1, V1), (1, v2, V2));

--- a/src/residuals/between.rs
+++ b/src/residuals/between.rs
@@ -65,8 +65,8 @@ where
     type DimOut = P::Dim;
     type DimIn = DimNameSum<P::Dim, P::Dim>;
 
-    fn residual2<D: Numeric>(&self, v1: P::Alias<D>, v2: P::Alias<D>) -> VectorX<D> {
-        let delta = P::dual_convert::<D>(&self.delta);
+    fn residual2<T: Numeric>(&self, v1: P::Alias<T>, v2: P::Alias<T>) -> VectorX<T> {
+        let delta = P::dual_convert::<T>(&self.delta);
         v1.compose(&delta).ominus(&v2)
     }
 }

--- a/src/residuals/imu_preint/newtypes.rs
+++ b/src/residuals/imu_preint/newtypes.rs
@@ -10,11 +10,11 @@ use crate::{
 /// aren't mixed up.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Gyro<D: Numeric = dtype>(pub Vector3<D>);
+pub struct Gyro<T: Numeric = dtype>(pub Vector3<T>);
 
-impl<D: Numeric> Gyro<D> {
+impl<T: Numeric> Gyro<T> {
     /// Remove the bias from the gyro measurement
-    pub fn remove_bias(&self, bias: &ImuBias<D>) -> GyroUnbiased<D> {
+    pub fn remove_bias(&self, bias: &ImuBias<T>) -> GyroUnbiased<T> {
         GyroUnbiased(self.0 - bias.gyro())
     }
 
@@ -22,13 +22,13 @@ impl<D: Numeric> Gyro<D> {
         Gyro(Vector3::zeros())
     }
 
-    pub fn new(x: D, y: D, z: D) -> Self {
+    pub fn new(x: T, y: T, z: T) -> Self {
         Gyro(Vector3::new(x, y, z))
     }
 }
 
 /// Gyro measurement with bias removed
-pub struct GyroUnbiased<D: Numeric = dtype>(pub Vector3<D>);
+pub struct GyroUnbiased<T: Numeric = dtype>(pub Vector3<T>);
 
 /// Raw accel measurement newtype
 ///
@@ -36,11 +36,11 @@ pub struct GyroUnbiased<D: Numeric = dtype>(pub Vector3<D>);
 /// aren't mixed up.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Accel<D: Numeric = dtype>(pub Vector3<D>);
+pub struct Accel<T: Numeric = dtype>(pub Vector3<T>);
 
-impl<D: Numeric> Accel<D> {
+impl<T: Numeric> Accel<T> {
     /// Remove the bias from the accel measurement
-    pub fn remove_bias(&self, bias: &ImuBias<D>) -> AccelUnbiased<D> {
+    pub fn remove_bias(&self, bias: &ImuBias<T>) -> AccelUnbiased<T> {
         AccelUnbiased(self.0 - bias.accel())
     }
 
@@ -48,13 +48,13 @@ impl<D: Numeric> Accel<D> {
         Accel(Vector3::zeros())
     }
 
-    pub fn new(x: D, y: D, z: D) -> Self {
+    pub fn new(x: T, y: T, z: T) -> Self {
         Accel(Vector3::new(x, y, z))
     }
 }
 
 /// Accel measurement with bias removed
-pub struct AccelUnbiased<D: Numeric = dtype>(pub Vector3<D>);
+pub struct AccelUnbiased<T: Numeric = dtype>(pub Vector3<T>);
 
 /// Gravity vector
 ///
@@ -62,26 +62,26 @@ pub struct AccelUnbiased<D: Numeric = dtype>(pub Vector3<D>);
 /// with other vectors and to provide some convenience methods.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Gravity<D: Numeric = dtype>(pub Vector3<D>);
+pub struct Gravity<T: Numeric = dtype>(pub Vector3<T>);
 
-impl<D: Numeric> Gravity<D> {
+impl<T: Numeric> Gravity<T> {
     /// Helper to get the gravity vector pointing up, i.e. [0, 0, 9.81]
     pub fn up() -> Self {
-        Gravity(Vector3::new(D::from(0.0), D::from(0.0), D::from(9.81)))
+        Gravity(Vector3::new(T::from(0.0), T::from(0.0), T::from(9.81)))
     }
 
     /// Helper to get the gravity vector pointing down, i.e. [0, 0, -9.81]
     pub fn down() -> Self {
-        Gravity(Vector3::new(D::from(0.0), D::from(0.0), D::from(-9.81)))
+        Gravity(Vector3::new(T::from(0.0), T::from(0.0), T::from(-9.81)))
     }
 }
 
 /// Struct to hold an Imu state
 ///
 /// Specifically holds an Imu state to which an ImuDelta can be applied
-pub struct ImuState<D: Numeric = dtype> {
-    pub r: SO3<D>,
-    pub v: Vector3<D>,
-    pub p: Vector3<D>,
-    pub bias: ImuBias<D>,
+pub struct ImuState<T: Numeric = dtype> {
+    pub r: SO3<T>,
+    pub v: Vector3<T>,
+    pub p: Vector3<T>,
+    pub bias: ImuBias<T>,
 }

--- a/src/residuals/imu_preint/residual.rs
+++ b/src/residuals/imu_preint/residual.rs
@@ -5,8 +5,7 @@ use nalgebra::Const;
 use super::{delta::ImuDelta, Accel, Gravity, Gyro, ImuState};
 use crate::{
     containers::{Factor, FactorBuilder, Symbol, TypedSymbol},
-    dtype,
-    impl_residual,
+    dtype, impl_residual,
     linalg::{ForwardProp, Matrix, Matrix3, VectorX},
     noise::GaussianNoise,
     residuals::Residual6,
@@ -307,17 +306,17 @@ impl Residual6 for ImuPreintegrationResidual {
     type V5 = VectorVar3;
     type V6 = ImuBias;
 
-    fn residual6<D: crate::linalg::Numeric>(
+    fn residual6<T: crate::linalg::Numeric>(
         &self,
-        x1: SE3<D>,
-        v1: VectorVar3<D>,
-        b1: ImuBias<D>,
-        x2: SE3<D>,
-        v2: VectorVar3<D>,
-        b2: ImuBias<D>,
-    ) -> VectorX<D> {
+        x1: SE3<T>,
+        v1: VectorVar3<T>,
+        b1: ImuBias<T>,
+        x2: SE3<T>,
+        v2: VectorVar3<T>,
+        b2: ImuBias<T>,
+    ) -> VectorX<T> {
         // Add dual types to all of our fields
-        let delta = ImuDelta::<D>::dual_convert(&self.delta);
+        let delta = ImuDelta::<T>::dual_convert(&self.delta);
 
         // Pull out the measurements
         let start = ImuState {
@@ -332,9 +331,9 @@ impl Residual6 for ImuPreintegrationResidual {
             p: p2_meas,
             bias: b2_meas,
         } = delta.predict(&start);
-        let p_2: VectorVar3<D> = x2.xyz().into_owned().into();
-        let p2_meas: VectorVar3<D> = p2_meas.into();
-        let v2_meas: VectorVar3<D> = v2_meas.into();
+        let p_2: VectorVar3<T> = x2.xyz().into_owned().into();
+        let p2_meas: VectorVar3<T> = p2_meas.into();
+        let v2_meas: VectorVar3<T> = v2_meas.into();
 
         // Compute residuals
         // Because of how the noise is integrated,

--- a/src/residuals/prior.rs
+++ b/src/residuals/prior.rs
@@ -58,8 +58,8 @@ where
     type DimIn = P::Dim;
     type DimOut = P::Dim;
 
-    fn residual1<D: Numeric>(&self, v: <Self::V1 as Variable>::Alias<D>) -> VectorX<D> {
-        Self::V1::dual_convert::<D>(&self.prior).ominus(&v)
+    fn residual1<T: Numeric>(&self, v: <Self::V1 as Variable>::Alias<T>) -> VectorX<T> {
+        Self::V1::dual_convert::<T>(&self.prior).ominus(&v)
     }
 }
 

--- a/src/residuals/traits.rs
+++ b/src/residuals/traits.rs
@@ -6,7 +6,7 @@ use crate::{
     variables::{Variable, VariableUmbrella},
 };
 
-type Alias<V, D> = <V as Variable>::Alias<D>;
+type Alias<V, T> = <V as Variable>::Alias<T>;
 
 // ------------------ Base Residual Trait & Helpers ------------------ //
 /// Base trait for residuals
@@ -48,9 +48,9 @@ pub trait ResidualSafe: Debug + Display {
 }
 
 impl<
-        #[cfg(not(feature = "serde"))] T: Residual,
-        #[cfg(feature = "serde")] T: Residual + crate::serde::Tagged,
-    > ResidualSafe for T
+        #[cfg(not(feature = "serde"))] R: Residual,
+        #[cfg(feature = "serde")] R: Residual + crate::serde::Tagged,
+    > ResidualSafe for R
 {
     fn dim_in(&self) -> usize {
         Residual::dim_in(self)
@@ -103,7 +103,7 @@ macro_rules! residual_maker {
                 ///
                 /// If implementing your own residual, this is the only method you need to implement.
                 /// It is generic over the dtype to allow for differentiable types.
-                fn [<residual $num>]<D: Numeric>(&self, $($name: Alias<Self::$var, D>,)*) -> VectorX<D>;
+                fn [<residual $num>]<T: Numeric>(&self, $($name: Alias<Self::$var, T>,)*) -> VectorX<T>;
 
                 #[doc="Wrapper that unpacks and calls [" [<residual $num>] "](Self::" [<residual $num>] ")."]
                 fn [<residual $num _values>](&self, values: &Values, keys: &[Key]) -> VectorX

--- a/src/variables/imu_bias.rs
+++ b/src/variables/imu_bias.rs
@@ -19,14 +19,14 @@ tag_variable!(ImuBias);
 /// treated as a 6D vector for optimization purposes.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ImuBias<D: Numeric = dtype> {
-    gyro: Vector3<D>,
-    accel: Vector3<D>,
+pub struct ImuBias<T: Numeric = dtype> {
+    gyro: Vector3<T>,
+    accel: Vector3<T>,
 }
 
-impl<D: Numeric> ImuBias<D> {
+impl<T: Numeric> ImuBias<T> {
     /// Create a new IMU bias
-    pub fn new(gyro: Gyro<D>, accel: Accel<D>) -> Self {
+    pub fn new(gyro: Gyro<T>, accel: Accel<T>) -> Self {
         ImuBias {
             gyro: gyro.0,
             accel: accel.0,
@@ -42,19 +42,19 @@ impl<D: Numeric> ImuBias<D> {
     }
 
     /// Get the gyro bias
-    pub fn gyro(&self) -> &Vector3<D> {
+    pub fn gyro(&self) -> &Vector3<T> {
         &self.gyro
     }
 
     /// Get the accel bias
-    pub fn accel(&self) -> &Vector3<D> {
+    pub fn accel(&self) -> &Vector3<T> {
         &self.accel
     }
 }
 
-impl<D: Numeric> Variable<D> for ImuBias<D> {
+impl<T: Numeric> Variable<T> for ImuBias<T> {
     type Dim = crate::linalg::Const<6>;
-    type Alias<DD: Numeric> = ImuBias<DD>;
+    type Alias<TT: Numeric> = ImuBias<TT>;
 
     fn identity() -> Self {
         ImuBias {
@@ -77,13 +77,13 @@ impl<D: Numeric> Variable<D> for ImuBias<D> {
         }
     }
 
-    fn exp(delta: crate::linalg::VectorViewX<D>) -> Self {
+    fn exp(delta: crate::linalg::VectorViewX<T>) -> Self {
         let gyro = Vector3::new(delta[0], delta[1], delta[2]);
         let accel = Vector3::new(delta[3], delta[4], delta[5]);
         ImuBias { gyro, accel }
     }
 
-    fn log(&self) -> crate::linalg::VectorX<D> {
+    fn log(&self) -> crate::linalg::VectorX<T> {
         crate::linalg::vectorx![
             self.gyro.x,
             self.gyro.y,
@@ -94,7 +94,7 @@ impl<D: Numeric> Variable<D> for ImuBias<D> {
         ]
     }
 
-    fn dual_convert<DD: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<DD> {
+    fn dual_convert<TT: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<TT> {
         ImuBias {
             gyro: other.gyro.map(|x| x.into()),
             accel: other.accel.map(|x| x.into()),
@@ -123,7 +123,7 @@ impl<D: Numeric> Variable<D> for ImuBias<D> {
     }
 }
 
-impl<D: Numeric> fmt::Display for ImuBias<D> {
+impl<T: Numeric> fmt::Display for ImuBias<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -133,13 +133,13 @@ impl<D: Numeric> fmt::Display for ImuBias<D> {
     }
 }
 
-impl<D: Numeric> fmt::Debug for ImuBias<D> {
+impl<T: Numeric> fmt::Debug for ImuBias<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
-impl<D: Numeric> ops::Sub for ImuBias<D> {
+impl<T: Numeric> ops::Sub for ImuBias<T> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -150,10 +150,10 @@ impl<D: Numeric> ops::Sub for ImuBias<D> {
     }
 }
 
-impl<'a, D: Numeric> ops::Sub for &'a ImuBias<D> {
-    type Output = ImuBias<D>;
+impl<'a, T: Numeric> ops::Sub for &'a ImuBias<T> {
+    type Output = ImuBias<T>;
 
-    fn sub(self, rhs: Self) -> ImuBias<D> {
+    fn sub(self, rhs: Self) -> ImuBias<T> {
         ImuBias {
             gyro: self.gyro - rhs.gyro,
             accel: self.accel - rhs.accel,

--- a/src/variables/macros.rs
+++ b/src/variables/macros.rs
@@ -145,10 +145,10 @@ macro_rules! test_lie {
             let v = VectorX::from_fn(vec_len, |i, _| (i + 1) as $crate::dtype);
 
             // Function that simply rotates a vector
-            fn rotate<D: $crate::linalg::Numeric>(r: $var<D>) -> $crate::linalg::VectorX<D> {
+            fn rotate<T: $crate::linalg::Numeric>(r: $var<T>) -> $crate::linalg::VectorX<T> {
                 let vec_len =
                     <$var as $crate::variables::MatrixLieGroup>::VectorDim::try_to_usize().unwrap();
-                let v = VectorX::from_fn(vec_len, |i, _| D::from((i + 1) as $crate::dtype));
+                let v = VectorX::from_fn(vec_len, |i, _| T::from((i + 1) as $crate::dtype));
                 let rotated = r.apply(v.as_view());
                 VectorX::from_fn(vec_len, |i, _| rotated[i].clone())
             }

--- a/src/variables/so2.rs
+++ b/src/variables/so2.rs
@@ -3,25 +3,9 @@ use std::{fmt, ops};
 use crate::{
     dtype,
     linalg::{
-        vectorx,
-        AllocatorBuffer,
-        Const,
-        DefaultAllocator,
-        Derivative,
-        DimName,
-        DualAllocator,
-        DualVector,
-        Matrix1,
-        Matrix2,
-        MatrixView,
-        Numeric,
-        Vector1,
-        Vector2,
-        VectorDim,
-        VectorView1,
-        VectorView2,
-        VectorViewX,
-        VectorX,
+        vectorx, AllocatorBuffer, Const, DefaultAllocator, Derivative, DimName, DualAllocator,
+        DualVector, Matrix1, Matrix2, MatrixView, Numeric, Vector1, Vector2, VectorDim,
+        VectorView1, VectorView2, VectorViewX, VectorX,
     },
     tag_variable,
     variables::{MatrixLieGroup, Variable},
@@ -35,15 +19,15 @@ tag_variable!(SO2);
 /// numbers to represent rotations.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SO2<D: Numeric = dtype> {
-    a: D,
-    b: D,
+pub struct SO2<T: Numeric = dtype> {
+    a: T,
+    b: T,
 }
 
-impl<D: Numeric> SO2<D> {
+impl<T: Numeric> SO2<T> {
     /// Create a new SO2 from an angle in radians
     #[allow(clippy::needless_borrow)]
-    pub fn from_theta(theta: D) -> Self {
+    pub fn from_theta(theta: T) -> Self {
         SO2 {
             a: (&theta).cos(),
             b: (&theta).sin(),
@@ -51,19 +35,19 @@ impl<D: Numeric> SO2<D> {
     }
 
     /// Convert SO2 to an angle in radians
-    pub fn to_theta(&self) -> D {
+    pub fn to_theta(&self) -> T {
         self.b.atan2(self.a)
     }
 }
 
-impl<D: Numeric> Variable<D> for SO2<D> {
+impl<T: Numeric> Variable<T> for SO2<T> {
     type Dim = Const<1>;
-    type Alias<DD: Numeric> = SO2<DD>;
+    type Alias<TT: Numeric> = SO2<TT>;
 
     fn identity() -> Self {
         SO2 {
-            a: D::from(1.0),
-            b: D::from(0.0),
+            a: T::from(1.0),
+            b: T::from(0.0),
         }
     }
 
@@ -81,17 +65,17 @@ impl<D: Numeric> Variable<D> for SO2<D> {
         }
     }
 
-    fn exp(xi: VectorViewX<D>) -> Self {
+    fn exp(xi: VectorViewX<T>) -> Self {
         let theta = xi[0];
         SO2::from_theta(theta)
     }
 
-    fn log(&self) -> VectorX<D> {
+    fn log(&self) -> VectorX<T> {
         vectorx![self.b.atan2(self.a)]
     }
 
-    fn dual_convert<DD: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<DD> {
-        Self::Alias::<DD> {
+    fn dual_convert<TT: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<TT> {
+        Self::Alias::<TT> {
             a: other.a.into(),
             b: other.b.into(),
         }
@@ -115,66 +99,66 @@ impl<D: Numeric> Variable<D> for SO2<D> {
     }
 }
 
-impl<D: Numeric> MatrixLieGroup<D> for SO2<D> {
+impl<T: Numeric> MatrixLieGroup<T> for SO2<T> {
     type TangentDim = Const<1>;
     type MatrixDim = Const<2>;
     type VectorDim = Const<2>;
 
-    fn adjoint(&self) -> Matrix1<D> {
+    fn adjoint(&self) -> Matrix1<T> {
         Matrix1::identity()
     }
 
-    fn hat(xi: VectorView1<D>) -> Matrix2<D> {
-        Matrix2::new(D::from(0.0), -xi[0], xi[0], D::from(0.0))
+    fn hat(xi: VectorView1<T>) -> Matrix2<T> {
+        Matrix2::new(T::from(0.0), -xi[0], xi[0], T::from(0.0))
     }
 
-    fn vee(xi: MatrixView<2, 2, D>) -> Vector1<D> {
+    fn vee(xi: MatrixView<2, 2, T>) -> Vector1<T> {
         Vector1::new(xi[(1, 0)])
     }
 
-    fn hat_swap(xi: VectorView2<D>) -> Vector2<D> {
+    fn hat_swap(xi: VectorView2<T>) -> Vector2<T> {
         Vector2::new(-xi[1], xi[0])
     }
 
-    fn apply(&self, v: VectorView2<D>) -> Vector2<D> {
+    fn apply(&self, v: VectorView2<T>) -> Vector2<T> {
         Vector2::new(v[0] * self.a - v[1] * self.b, v[0] * self.b + v[1] * self.a)
     }
 
-    fn from_matrix(mat: MatrixView<2, 2, D>) -> Self {
+    fn from_matrix(mat: MatrixView<2, 2, T>) -> Self {
         SO2 {
             a: mat[(0, 0)],
             b: mat[(1, 0)],
         }
     }
 
-    fn to_matrix(&self) -> Matrix2<D> {
+    fn to_matrix(&self) -> Matrix2<T> {
         Matrix2::new(self.a, -self.b, self.b, self.a)
     }
 }
 
-impl<D: Numeric> ops::Mul for SO2<D> {
-    type Output = SO2<D>;
+impl<T: Numeric> ops::Mul for SO2<T> {
+    type Output = SO2<T>;
 
     fn mul(self, other: Self) -> Self::Output {
         self.compose(&other)
     }
 }
 
-impl<D: Numeric> ops::Mul for &SO2<D> {
-    type Output = SO2<D>;
+impl<T: Numeric> ops::Mul for &SO2<T> {
+    type Output = SO2<T>;
 
     fn mul(self, other: Self) -> Self::Output {
         self.compose(other)
     }
 }
 
-impl<D: Numeric> fmt::Display for SO2<D> {
+impl<T: Numeric> fmt::Display for SO2<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SO2({:.3})", self.log()[0])
     }
 }
 
-impl<D: Numeric> fmt::Debug for SO2<D> {
+impl<T: Numeric> fmt::Debug for SO2<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SO2(a: {:.3}, b: {:.3})", self.a, self.b)
     }

--- a/src/variables/vector.rs
+++ b/src/variables/vector.rs
@@ -6,17 +6,8 @@ use std::{
 use crate::{
     dtype,
     linalg::{
-        AllocatorBuffer,
-        Const,
-        DefaultAllocator,
-        DimName,
-        DualAllocator,
-        DualVector,
-        Numeric,
-        Vector,
-        VectorDim,
-        VectorViewX,
-        VectorX,
+        AllocatorBuffer, Const, DefaultAllocator, DimName, DualAllocator, DualVector, Numeric,
+        Vector, VectorDim, VectorViewX, VectorX,
     },
     tag_variable,
     variables::Variable,
@@ -40,11 +31,11 @@ tag_variable!(
 /// 3 - Impl Into\<Rerun types\>
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct VectorVar<const N: usize, D: Numeric = dtype>(pub Vector<N, D>);
+pub struct VectorVar<const N: usize, T: Numeric = dtype>(pub Vector<N, T>);
 
-impl<const N: usize, D: Numeric> Variable<D> for VectorVar<N, D> {
+impl<const N: usize, T: Numeric> Variable<T> for VectorVar<N, T> {
     type Dim = Const<N>;
-    type Alias<DD: Numeric> = VectorVar<N, DD>;
+    type Alias<TT: Numeric> = VectorVar<N, TT>;
 
     fn identity() -> Self {
         VectorVar(Vector::zeros())
@@ -58,15 +49,15 @@ impl<const N: usize, D: Numeric> Variable<D> for VectorVar<N, D> {
         VectorVar(self.0 + other.0)
     }
 
-    fn exp(delta: VectorViewX<D>) -> Self {
+    fn exp(delta: VectorViewX<T>) -> Self {
         VectorVar(Vector::from_iterator(delta.iter().cloned()))
     }
 
-    fn log(&self) -> VectorX<D> {
+    fn log(&self) -> VectorX<T> {
         VectorX::from_iterator(Self::DIM, self.0.iter().cloned())
     }
 
-    fn dual_convert<DD: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<DD> {
+    fn dual_convert<TT: Numeric>(other: &Self::Alias<dtype>) -> Self::Alias<TT> {
         VectorVar(other.0.map(|x| x.into()))
     }
 
@@ -88,9 +79,9 @@ impl<const N: usize, D: Numeric> Variable<D> for VectorVar<N, D> {
 
 macro_rules! impl_vector_new {
     ($($num:literal, [$($args:ident),*]);* $(;)?) => {$(
-        impl<D: Numeric> VectorVar<$num, D> {
-            pub fn new($($args: D),*) -> Self {
-                VectorVar(Vector::<$num, D>::new($($args),*))
+        impl<T: Numeric> VectorVar<$num, T> {
+            pub fn new($($args: T),*) -> Self {
+                VectorVar(Vector::<$num, T>::new($($args),*))
             }
         }
     )*};
@@ -105,19 +96,19 @@ impl_vector_new!(
     6, [x, y, z, w, a, b];
 );
 
-impl<const N: usize, D: Numeric> From<Vector<N, D>> for VectorVar<N, D> {
-    fn from(v: Vector<N, D>) -> Self {
+impl<const N: usize, T: Numeric> From<Vector<N, T>> for VectorVar<N, T> {
+    fn from(v: Vector<N, T>) -> Self {
         VectorVar(v)
     }
 }
 
-impl<const N: usize, D: Numeric> From<VectorVar<N, D>> for Vector<N, D> {
-    fn from(v: VectorVar<N, D>) -> Self {
+impl<const N: usize, T: Numeric> From<VectorVar<N, T>> for Vector<N, T> {
+    fn from(v: VectorVar<N, T>) -> Self {
         v.0
     }
 }
 
-impl<const N: usize, D: Numeric> Display for VectorVar<N, D> {
+impl<const N: usize, T: Numeric> Display for VectorVar<N, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Vector{}(", N)?;
         for (i, x) in self.0.iter().enumerate() {
@@ -130,14 +121,14 @@ impl<const N: usize, D: Numeric> Display for VectorVar<N, D> {
     }
 }
 
-impl<const N: usize, D: Numeric> Debug for VectorVar<N, D> {
+impl<const N: usize, T: Numeric> Debug for VectorVar<N, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<const N: usize, D: Numeric> Index<usize> for VectorVar<N, D> {
-    type Output = D;
+impl<const N: usize, T: Numeric> Index<usize> for VectorVar<N, T> {
+    type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
@@ -145,17 +136,17 @@ impl<const N: usize, D: Numeric> Index<usize> for VectorVar<N, D> {
 }
 
 /// 1D Vector Variable
-pub type VectorVar1<D = dtype> = VectorVar<1, D>;
+pub type VectorVar1<T = dtype> = VectorVar<1, T>;
 /// 2D Vector Variable
-pub type VectorVar2<D = dtype> = VectorVar<2, D>;
+pub type VectorVar2<T = dtype> = VectorVar<2, T>;
 /// 3D Vector Variable
-pub type VectorVar3<D = dtype> = VectorVar<3, D>;
+pub type VectorVar3<T = dtype> = VectorVar<3, T>;
 /// 4D Vector Variable
-pub type VectorVar4<D = dtype> = VectorVar<4, D>;
+pub type VectorVar4<T = dtype> = VectorVar<4, T>;
 /// 5D Vector Variable
-pub type VectorVar5<D = dtype> = VectorVar<5, D>;
+pub type VectorVar5<T = dtype> = VectorVar<5, T>;
 /// 6D Vector Variable
-pub type VectorVar6<D = dtype> = VectorVar<6, D>;
+pub type VectorVar6<T = dtype> = VectorVar<6, T>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
To fit the widely used convention, we rename all our dtype generics from "D" to "T". No functional change here