### PR TITLE
Add fac! macro for factor construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We recommend you checkout the [docs](https://docs.rs/factrs/latest/factrs/) for 
 ```rust
 use factrs::{
    assign_symbols,
+   fac,
    containers::{FactorBuilder, Graph, Values},
    noise::GaussianNoise,
    optimizers::GaussNewton,
@@ -48,16 +49,18 @@ values.insert(X(1), SO2::identity());
 // Make the factors & insert into graph
 let mut graph = Graph::new();
 let res = PriorResidual::new(x.clone());
-let factor = FactorBuilder::new1(res, X(0)).build();
+let factor = fac![res, X(0)];
 graph.add_factor(factor);
 
 let res = BetweenResidual::new(y.minus(&x));
 let noise = GaussianNoise::from_scalar_sigma(0.1);
 let robust = Huber::default();
-let factor = FactorBuilder::new2(res, X(0), X(1))
-    .noise(noise)
-    .robust(robust)
-    .build();
+let factor = fac![res, (X(0), X(1)), noise, robust];
+// The same as above, but verbose
+// let factor = FactorBuilder::new2(res, X(0), X(1))
+//     .noise(noise)
+//     .robust(robust)
+//     .build();
 graph.add_factor(factor);
 
 // Optimize!

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,5 +1,6 @@
 use factrs::{
     containers::{FactorBuilder, Graph, Values, X},
+    fac,
     factors::Factor,
     noise::GaussianNoise,
     residuals::{BetweenResidual, PriorResidual},
@@ -26,13 +27,14 @@ fn main() {
     let prior = PriorResidual::new(x);
     let bet = BetweenResidual::new(y);
 
-    let prior = FactorBuilder::new1(prior, X(0))
-        .noise(GaussianNoise::from_scalar_cov(0.1))
-        .robust(GemanMcClure::default())
-        .build();
-    let bet = FactorBuilder::new2(bet, X(0), X(1))
-        .noise(GaussianNoise::from_scalar_cov(10.0))
-        .build();
+    let prior = fac![
+        prior,
+        X(0),
+        GaussianNoise::from_scalar_cov(0.1),
+        GemanMcClure::default()
+    ];
+    let bet = fac![res, (X(0), X(1)), GaussianNoise::from_scalar_cov(10.0)];
+
     let mut graph = Graph::new();
     graph.add_factor(prior);
     graph.add_factor(bet);

--- a/factrs-proc/src/fac.rs
+++ b/factrs-proc/src/fac.rs
@@ -1,0 +1,110 @@
+use proc_macro2::Span;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{parse::Parse, punctuated::Punctuated, Expr, Ident, Token};
+
+pub struct Factor {
+    residual: Expr,
+    keys: Punctuated<Expr, Token![,]>,
+    noise: Option<Expr>,
+    robust: Option<Expr>,
+}
+
+impl Factor {
+    fn noise_call(&self) -> TokenStream2 {
+        match &self.noise {
+            Some(n) => quote! { .noise(#n) },
+            None => TokenStream2::new(),
+        }
+    }
+
+    fn robust_call(&self) -> TokenStream2 {
+        match &self.robust {
+            Some(r) => quote! {.robust(#r) },
+            None => TokenStream2::new(),
+        }
+    }
+
+    fn new_call(&self) -> TokenStream2 {
+        let func = Ident::new(&format!("new{}", self.keys.len()), Span::call_site());
+        let res = &self.residual;
+        let keys = &self.keys;
+        return quote! { #func(#res, #keys) };
+    }
+}
+
+impl Parse for Factor {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let input = Punctuated::<Expr, Token![,]>::parse_terminated(input)?;
+
+        // Make sure we go the right number of arguments
+        if input.len() < 2 {
+            return Err(syn::Error::new_spanned(
+                &input[0],
+                "Expected at least two items",
+            ));
+        } else if input.len() > 4 {
+            return Err(syn::Error::new_spanned(
+                &input.last(),
+                "Expected at most four items",
+            ));
+        }
+
+        // Residual is first
+        let residual = input[0].clone();
+
+        // Then the keys
+        let keys = match &input[1] {
+            // in brackets
+            Expr::Array(a) => a.elems.clone(),
+            // in parantheses
+            Expr::Tuple(t) => t.elems.clone(),
+            // a single key for unary factors
+            Expr::Path(_) => {
+                let mut p = Punctuated::<Expr, Token![,]>::new();
+                p.push(input[1].clone());
+                p
+            }
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    &input[1],
+                    "Expected keys in brackets or parantheses",
+                ));
+            }
+        };
+
+        // TODO: Someway to input robust without noise?
+        // Then the noise
+        let noise = if input.len() >= 3 {
+            Some(input[2].clone())
+        } else {
+            None
+        };
+
+        // Finally robust cost function
+        let robust = if input.len() == 4 {
+            Some(input[3].clone())
+        } else {
+            None
+        };
+
+        Ok(Factor {
+            residual,
+            keys,
+            noise,
+            robust,
+        })
+    }
+}
+
+pub fn fac(factor: Factor) -> TokenStream2 {
+    let call = factor.new_call();
+    let noise = factor.robust_call();
+    let robust = factor.noise_call();
+
+    let out = quote! {
+        factrs::containers::FactorBuilder:: #call #noise #robust.build()
+    };
+
+    out
+}

--- a/factrs-proc/src/fac.rs
+++ b/factrs-proc/src/fac.rs
@@ -57,7 +57,7 @@ impl Parse for Factor {
         let keys = match &input[1] {
             // in brackets
             Expr::Array(a) => a.elems.clone(),
-            // in parantheses
+            // in parentheses
             Expr::Tuple(t) => t.elems.clone(),
             // a single key for unary factors
             Expr::Path(_) => {
@@ -68,12 +68,11 @@ impl Parse for Factor {
             _ => {
                 return Err(syn::Error::new_spanned(
                     &input[1],
-                    "Expected keys in brackets or parantheses",
+                    "Expected keys in brackets or parentheses",
                 ));
             }
         };
 
-        // TODO: Someway to input robust without noise?
         // Then the noise
         let noise = if input.len() >= 3 {
             Some(input[2].clone())

--- a/factrs-proc/src/lib.rs
+++ b/factrs-proc/src/lib.rs
@@ -7,10 +7,6 @@ mod residual;
 mod robust;
 mod variable;
 
-mod kw {
-    syn::custom_keyword!(path);
-}
-
 enum BoxedTypes {
     Residual,
     Variable,
@@ -53,7 +49,7 @@ pub fn mark(
 
     let trait_type = match check_type(&input) {
         Ok(syntax_tree) => syntax_tree,
-        Err(err) => return proc_macro::TokenStream::from(err.to_compile_error()),
+        Err(err) => return err.to_compile_error().into(),
     };
 
     match trait_type {

--- a/factrs-proc/src/lib.rs
+++ b/factrs-proc/src/lib.rs
@@ -1,6 +1,15 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse::Parser, punctuated::Punctuated, Item};
+use syn::{parse::Parser, parse_macro_input, punctuated::Punctuated, Item};
+
+mod fac;
+
+#[proc_macro]
+pub fn fac(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let factor = parse_macro_input!(input as fac::Factor);
+
+    fac::fac(factor).into()
+}
 
 #[proc_macro_attribute]
 pub fn mark_residual(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,13 @@ pub type dtype = f64;
 #[allow(non_camel_case_types)]
 pub type dtype = f32;
 
+pub use factrs_proc::fac;
+
+// Hack to be able to use our proc macro inside and out of our crate
+// https://users.rust-lang.org/t/how-to-express-crate-path-in-procedural-macros/91274/10
+#[doc(hidden)]
+extern crate self as factrs;
+
 pub mod containers;
 pub mod linalg;
 pub mod linear;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     assign_symbols,
     containers::{FactorBuilder, Graph, Values},
-    dtype,
+    dtype, fac,
     linalg::{Matrix3, Matrix6, Vector3},
     noise::GaussianNoise,
     residuals::{BetweenResidual, PriorResidual},
@@ -41,7 +41,7 @@ pub fn load_g20(file: &str) -> (Graph, Values) {
 
                 // Add prior on whatever the first variable is
                 if values.len() == 1 {
-                    let factor = FactorBuilder::new1(PriorResidual::new(var.clone()), key).build();
+                    let factor = fac![PriorResidual::new(var.clone()), key];
                     graph.add_factor(factor);
                 }
 
@@ -67,9 +67,7 @@ pub fn load_g20(file: &str) -> (Graph, Values) {
                 let key2 = X(id_curr);
                 let var = SE2::new(theta, x, y);
                 let noise = GaussianNoise::from_matrix_inf(inf.as_view());
-                let factor = FactorBuilder::new2(BetweenResidual::new(var), key1, key2)
-                    .noise(noise)
-                    .build();
+                let factor = fac![BetweenResidual::new(var), (key1, key2), noise];
                 graph.add_factor(factor);
             }
 
@@ -92,9 +90,7 @@ pub fn load_g20(file: &str) -> (Graph, Values) {
                 if values.len() == 1 {
                     let noise =
                         GaussianNoise::<6>::from_diag_covs(1e-6, 1e-6, 1e-6, 1e-4, 1e-4, 1e-4);
-                    let factor = FactorBuilder::new1(PriorResidual::new(var.clone()), key)
-                        .noise(noise)
-                        .build();
+                    let factor = fac![PriorResidual::new(var.clone()), key, noise];
                     graph.add_factor(factor);
                 }
 


### PR DESCRIPTION
Following my new-found love for proc-macros, this adds the `fac!` macro for easy factor creation. Essentially this,

```rust
let factor = FactorBuilder::new2(res, X(0), X(1))
    .noise(noise)
    .robust(robust)
    .build();
```

Now becomes this,
```rust
factor = fac![res, (X(0), X(1)), noise, robust];
```

but still retains the symbol type checking, residual input # checking, and residual output/noise dimension checking.