### PR TITLE
Clean up fac! noise as literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ let factor = fac![res, X(0)];
 graph.add_factor(factor);
 
 let res = BetweenResidual::new(y.minus(&x));
-let noise = GaussianNoise::from_scalar_sigma(0.1);
 let robust = Huber::default();
-let factor = fac![res, (X(0), X(1)), noise, robust];
+let factor = fac![res, (X(0), X(1)), 0.1 as std, robust];
 // The same as above, but verbose
+// let noise = GaussianNoise::from_scalar_sigma(0.1);
 // let factor = FactorBuilder::new2(res, X(0), X(1))
 //     .noise(noise)
 //     .robust(robust)

--- a/src/residuals/imu_preint/residual.rs
+++ b/src/residuals/imu_preint/residual.rs
@@ -396,9 +396,9 @@ mod test {
         // Build factor and graph
         let mut graph = Graph::new();
         let factor = preint.build(X(0), V(0), B(0), X(1), V(1), B(1));
-        let prior_x0 = fac!(PriorResidual::new(x0.clone()), X(0), 1e-3);
-        let prior_v0 = fac!(PriorResidual::new(v0.clone()), V(0), 1e-3);
-        let prior_b0 = fac!(PriorResidual::new(b0.clone()), B(0), 1e-3);
+        let prior_x0 = fac!(PriorResidual::new(x0.clone()), X(0), 1e-3 as cov);
+        let prior_v0 = fac!(PriorResidual::new(v0.clone()), V(0), 1e-3 as cov);
+        let prior_b0 = fac!(PriorResidual::new(b0.clone()), B(0), 1e-3 as cov);
         graph.add_factor(factor);
         graph.add_factor(prior_x0);
         graph.add_factor(prior_v0);


### PR DESCRIPTION
I wasn't pleased with the original usage of noise literals in the `fac` macro as it left things a little ambiguous as to whether it was a standard deviation or covariance. This small tweak now requires it to be "casted" into one of the two - `0.1 as cov` or `0.1 as std`. 

Additionally, the noise can now be defaulted to UnitNoise using `_`. 