### PR TITLE
Require `Send` for `Graph` and `Factor`

### DIFF
--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -11,7 +11,7 @@ use crate::linalg::{DimName, MatrixX, VectorX};
 
 /// The trait for a noise model.
 #[cfg_attr(feature = "serde", typetag::serde(tag = "tag"))]
-pub trait NoiseModel: Debug + DynClone {
+pub trait NoiseModel: Debug + DynClone + Send {
     /// The dimension of the noise model
     type Dim: DimName
     where

--- a/src/residuals/prior.rs
+++ b/src/residuals/prior.rs
@@ -28,7 +28,7 @@ impl<P: VariableDtype> PriorResidual<P> {
 #[factrs::mark]
 impl<P> Residual1 for PriorResidual<P>
 where
-    P: VariableDtype + 'static,
+    P: VariableDtype + 'static + Send,
     AllocatorBuffer<P::Dim>: Sync + Send,
     DefaultAllocator: DualAllocator<P::Dim>,
     DualVector<P::Dim>: Copy,

--- a/src/residuals/traits.rs
+++ b/src/residuals/traits.rs
@@ -17,7 +17,7 @@ type Alias<V, T> = <V as Variable>::Alias<T>;
 /// implement one of the `ResidualN` traits, and then [mark](factrs::mark) it to
 /// implement this.
 #[cfg_attr(feature = "serde", typetag::serde(tag = "tag"))]
-pub trait Residual: Debug + DynClone {
+pub trait Residual: Debug + DynClone + Send {
     fn dim_in(&self) -> usize;
 
     fn dim_out(&self) -> usize;

--- a/src/robust/mod.rs
+++ b/src/robust/mod.rs
@@ -33,7 +33,7 @@ use crate::dtype;
 /// to implement your own kernel, we recommend using
 /// [test_robust](crate::test_robust) to ensure weight = loss'(d) / d
 #[cfg_attr(feature = "serde", typetag::serde(tag = "tag"))]
-pub trait RobustCost: Debug + DynClone {
+pub trait RobustCost: Debug + DynClone + Send {
     /// Compute the loss \rho(x^2)
     fn loss(&self, d2: dtype) -> dtype;
 

--- a/src/variables/traits.rs
+++ b/src/variables/traits.rs
@@ -15,7 +15,7 @@ use crate::{
 /// All variables must implement this trait to be used in the optimization
 /// algorithms. See [module level documentation](crate::variables) for more
 /// details.
-pub trait Variable: Clone + Sized + Display + Debug {
+pub trait Variable: Clone + Sized + Display + Debug + Send {
     /// Datatype of the variable
     type T: Numeric;
     /// Dimension of the Lie group / Tangent space
@@ -177,7 +177,7 @@ pub trait Variable: Clone + Sized + Display + Debug {
 /// Implemented for all types that implement [Variable].
 // TODO: Rename to VariableGeneric? Something like that
 #[cfg_attr(feature = "serde", typetag::serde(tag = "tag"))]
-pub trait VariableSafe: Debug + Display + Downcast {
+pub trait VariableSafe: Debug + Display + Downcast + Send {
     fn clone_box(&self) -> Box<dyn VariableSafe>;
 
     fn dim(&self) -> usize;

--- a/tests/graph_and_factors_are_send.rs
+++ b/tests/graph_and_factors_are_send.rs
@@ -1,0 +1,13 @@
+use factrs::core::{Factor, Graph};
+
+fn assert_send<T: Send>() {}
+
+#[test]
+fn graph_is_send() {
+    assert_send::<Graph>();
+}
+
+#[test]
+fn factor_is_send() {
+    assert_send::<Factor>();
+}


### PR DESCRIPTION
I am currently implementing a Visual-Inertial localization system based on `fact-rs`. I want to run my backend in a separate thread, which requires the `Graph` and `Factor`s to be `Send`.
This PR adds the required `Send` bounds to all relevant traits.

I also added "tests", which require `Graph` and `Factor` to be `Send`. These are not real tests, since they are evaluated at compile-time. I am open to suggestions here.