### PR TITLE
Invalidate sparsity pattern cache

### DIFF
--- a/src/linear/solvers.rs
+++ b/src/linear/solvers.rs
@@ -10,6 +10,9 @@ use crate::dtype;
 
 /// Trait to solve sparse linear systems
 pub trait LinearSolver {
+    /// Invalidate any cached data in the solver
+    fn invalidate(&mut self) {}
+
     /// Solve a symmetric linear system
     ///
     /// This will be used by Cholesky to solve A^T A and by Levenberg-Marquardt
@@ -39,6 +42,10 @@ pub struct CholeskySolver {
 }
 
 impl LinearSolver for CholeskySolver {
+    fn invalidate(&mut self) {
+        self.sparsity_pattern = None;
+    }
+
     fn solve_symmetric(
         &mut self,
         a: SparseColMatRef<usize, dtype>,
@@ -84,6 +91,10 @@ pub struct QRSolver {
 }
 
 impl LinearSolver for QRSolver {
+    fn invalidate(&mut self) {
+        self.sparsity_pattern = None;
+    }
+
     fn solve_symmetric(
         &mut self,
         a: SparseColMatRef<usize, dtype>,
@@ -120,6 +131,10 @@ pub struct LUSolver {
 }
 
 impl LinearSolver for LUSolver {
+    fn invalidate(&mut self) {
+        self.sparsity_pattern = None;
+    }
+
     fn solve_symmetric(
         &mut self,
         a: SparseColMatRef<usize, dtype>,

--- a/src/optimizers/gauss_newton.rs
+++ b/src/optimizers/gauss_newton.rs
@@ -76,6 +76,7 @@ impl Optimizer for GaussNewton {
             self.graph
                 .sparsity_pattern(ValuesOrder::from_values(_values)),
         );
+        self.solver.invalidate();
 
         Vec::new()
     }

--- a/src/optimizers/levenberg_marquardt.rs
+++ b/src/optimizers/levenberg_marquardt.rs
@@ -43,7 +43,7 @@ impl OptParams for LevenParams {
 
 /// The Levenberg-Marquadt optimizer
 ///
-/// Solves a damped version of the normal equations,  
+/// Solves a damped version of the normal equations,
 /// $$A^\top A \Delta \Theta + \lambda diag(A) = A^\top b$$
 /// each optimizer steps. It defaults
 /// to using [CholeskySolver](crate::linear::CholeskySolver) under the hood, but
@@ -114,6 +114,7 @@ impl Optimizer for LevenMarquardt {
             self.graph
                 .sparsity_pattern(ValuesOrder::from_values(values)),
         );
+        self.solver.invalidate();
 
         vec!["   Lambda   ", "  Fidelity  "]
     }


### PR DESCRIPTION
Currently all of the linear solvers cache the sparsity pattern.
I am not entirely sure how this was planned on your side, but for me this regularly panics when I update the graph with new factors between solver rounds.
I added a very simple invalidation, causing the sparsity pattern to be recomputed after each optimize call.

If you have better ideas on how to achieve invalidation I am open to suggestions!